### PR TITLE
commit package-lock.json changes to safe-buffer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14568,7 +14568,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",


### PR DESCRIPTION
commit package-lock.json changes to safe-buffer package (no idea what the change is, committing as git is showing package-lock.json as modified after an npm install